### PR TITLE
I made some changes!

### DIFF
--- a/draft-bellis-dnsop-qdcount-is-one.md
+++ b/draft-bellis-dnsop-qdcount-is-one.md
@@ -1,5 +1,5 @@
 ---
-title: DNS QDCOUNT is (usually) ONE
+title: In the DNS, QDCOUNT is (usually) One
 docname: draft-bellis-dnsop-qdcount-is-one-00
 updates: RFC1035
 
@@ -25,35 +25,45 @@ author:
     street: PO Box 360
     city: Newmarket
     code: NH 03857
-    country: USA
+    country: US
     phone: +1 650 423 1300
     email: ray@isc.org
   -
     ins: J. Abley
     name: Joe Abley
-    email: jabley@hopcount.ca
+    org: Cloudflare
+    city: Amsterdam
+    country: NL
+    phone: +31 6 45 56 36 34
+    email: jabley@cloudflare.com
 
 --- abstract
 
-This document clarifies the legal values for the QDCOUNT header
-value in the current DNS specifications.
+This document clarifies the allowable values of the QDCOUNT parameter
+in DNS messages with OPCODE = 0 (QUERY) and specifies the required
+behaviour when values that are not allowed are encountered.
 
 --- middle
 
 # Introduction
 
-An oft-repeated claim is that the DNS protocol {{!RFC1034}}{{!RFC1035}}
-theoreticaly permits a DNS query to contain more than one question.
+The DNS protocol {{!RFC1034}{{!RFC1035}} includes a parameter QDCOUNT in the
+DNS message header, whose value is specified to mean the number
+of questions in the Question Section of a message.
 
-While this claim might initially appear valid (the QDCOUNT field is a
-16-bit field with a range of 0 .. 65535) in practise there are other
-limitations inherent in the protocol that make use of a QDCOUNT greater
-than one impractical.  In particular there are no defined semantics for
-how to handle those response fields that might vary for different QNAMEs
-(e.g. AA bit, RCODE).
+In a general
+sense it seems perfectly plausible for the QDCOUNT parameter, an unsigned
+16-bit value, to take a considerable range of values. However, in the
+specific case of messages that encode DNS queries (messages with OPCODE
+= 0) there are other limitations inherent in the protocol that constrain
+values of QDCOUNT to be either 0 or 1. In particular, several parameters
+specified for DNS response messages such as AA and RCODE have no defined
+meaning when the message contains multiple queries, since there is no way
+to signal which question those parameters relate to.
 
-In this document we normatively clarify the currently legal values of
-the QDCOUNT field, especially when applied to the Query OpCode.
+In this document we clarify the allowable values of the QDCODE parameter
+in DNS messages with OPCODE = 0 (QUERY). We also briefly survey the use
+of this parameter by other types of DNS messages with OPCODE = 
 
 # Terminology used in this document
 
@@ -63,10 +73,10 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 {{!RFC2119}} {{!RFC8174}} when, and only when, they appear in all
 capitals, as shown here.
 
-# QDCOUNT is (almost always) one
+# QDCOUNT in Queries is (almost always) one
 
 {{!RFC1035}} significantly predates the use of normative requirements
-keywords, and parts of it are therefore somewhat open to interpretation.
+keywords, and parts of it are consequently somewhat open to interpretation.
 
 Section 4.1.2 ("Question section format") has this to say about QDCOUNT:
 
@@ -75,9 +85,8 @@ Section 4.1.2 ("Question section format") has this to say about QDCOUNT:
 However, the only documented exceptions within {{!RFC1035}} relate to
 the IQuery Opcode, where the request has "an empty question section"
 (QDCOUNT == 0), and "zero, one, or multiple domain names for the
-specified resource as QNAMEs in the question section".
-
-The IQuery OpCode was formally obsoleted in {{!RFC3425}}.
+specified resource as QNAMEs in the question section". The IQuery OpCode
+was made obsolete in {{!RFC3425}}.
 
 In the absence of clearly expressed normative requirements, we rely on
 other text in {{!RFC1035}} that makes use of the definite article or
@@ -99,8 +108,6 @@ and in Section 4.1.1. ("Header section format"):
 >    authority for the domain name in question section.
 
 ## Exceptions
-
-There is one exception to QDCOUNT == 1.
 
 DNS Cookies {{?RFC7873}} in Section 5.4 allow a client to receive a
 valid Server Cookie without sending a specific question by sending a
@@ -149,6 +156,6 @@ This document has no security implications.
 
 # IANA Considerations
 
-This document has no IANA considerations.
+This document has no IANA actions.
 
 --- back

--- a/draft-bellis-dnsop-qdcount-is-one.md
+++ b/draft-bellis-dnsop-qdcount-is-one.md
@@ -54,16 +54,19 @@ of questions in the Question Section of a message.
 In a general
 sense it seems perfectly plausible for the QDCOUNT parameter, an unsigned
 16-bit value, to take a considerable range of values. However, in the
-specific case of messages that encode DNS queries (messages with OPCODE
+specific case of messages that encode DNS queries and responses (messages with OPCODE
 = 0) there are other limitations inherent in the protocol that constrain
 values of QDCOUNT to be either 0 or 1. In particular, several parameters
 specified for DNS response messages such as AA and RCODE have no defined
 meaning when the message contains multiple queries, since there is no way
 to signal which question those parameters relate to.
 
-In this document we clarify the allowable values of the QDCODE parameter
-in DNS messages with OPCODE = 0 (QUERY). We also briefly survey the use
-of this parameter by other types of DNS messages with OPCODE = 
+In this document we briefly survey the existing written DNS specification;
+we provide a description of the semantic and practical requirements for
+DNS queries that naturally constrain the allowable values of QDCOUNT; and
+we update the DNS base specification to clarify the allowable values
+of the QDCODE parameter in the specific case of DNS messages with OPCODE = 0
+(QUERY).
 
 # Terminology used in this document
 
@@ -73,7 +76,12 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 {{!RFC2119}} {{!RFC8174}} when, and only when, they appear in all
 capitals, as shown here.
 
-# QDCOUNT in Queries is (almost always) one
+# QDCOUNT is (usually) One
+
+The following brief survey provides some commentary on the use of
+QDCOUNT in the written DNS specification.
+
+## OPCODE = 0 (QUERY) and 1 (IQUERY)
 
 {{!RFC1035}} significantly predates the use of normative requirements
 keywords, and parts of it are consequently somewhat open to interpretation.
@@ -82,7 +90,7 @@ Section 4.1.2 ("Question section format") has this to say about QDCOUNT:
 
 > The section contains QDCOUNT (usually 1) entries
 
-However, the only documented exceptions within {{!RFC1035}} relate to
+The only documented exceptions within {{!RFC1035}} relate to
 the IQuery Opcode, where the request has "an empty question section"
 (QDCOUNT == 0), and "zero, one, or multiple domain names for the
 specified resource as QNAMEs in the question section". The IQuery OpCode
@@ -107,16 +115,12 @@ and in Section 4.1.1. ("Header section format"):
 >    and specifies that the responding name server is an
 >    authority for the domain name in question section.
 
-## Exceptions
-
 DNS Cookies {{?RFC7873}} in Section 5.4 allow a client to receive a
 valid Server Cookie without sending a specific question by sending a
 Query packet (OpCode 0) with QDCOUNT == 0, with the resulting response
 also containing no question.
 
-# Other DNS Opcodes
-
-## DNS Notify
+## OPCODE = 4 (NOTIFY)
 
 DNS Notify {{?RFC1996}} also lacks a clearly defined range of values
 for QDCOUNT.  Section 3.7 says:
@@ -126,7 +130,7 @@ for QDCOUNT.  Section 3.7 says:
 but all other text in the RFC talks about the <QNAME, QCLASS, QTYPE>
 tuple in the singular.
 
-## DNS Update
+## OPCODE = 5 (UPDATE)
 
 DNS Update {{?RFC2136}} renames the QDCOUNT field to ZOCOUNT, but the
 value is constrained to be one by Section 2.3 ("Zone Section"):
@@ -134,25 +138,47 @@ value is constrained to be one by Section 2.3 ("Zone Section"):
 > All records to be updated must be in the same zone, and therefore the
 > Zone Section is allowed to contain exactly one record.
 
-## DNS Stateful Operations
+## OPCODE = 6 (DNS Stateful Operations, DSO)
 
 DNS Stateful Operations {{?RFC8490}} (DSO - OpCode 6) attempts to
 preserve compatibility with the standard DNS 12 octet header, and does
 so by requiring that all four of the section count values be set to
 zero.
 
-# Conclusion
+## Conclusion
 
-The only legal values of the 16-bit word contained in octets 4 and 5 of
-the DNS header (usually called QDCOUNT) are zero (rarely) and one,
-otherwise.
+There is no description in {{!RFC1035}} that describes how other parameters
+in the DNS message such as AA, RCODE should be interpreted in the case
+where a message includes more than one question. An originator of a query
+with QDCOUNT > 1 can have no expectations of how it will be processed,
+and the receiver of a response with QDCOUNT > 1 has no guidance for how it
+should be interpreted.
 
-Future OpCodes may define other uses and legal values for the header
-octets used by this field.
+The allowable values of QDCOUNT seem to be clearly specified for OPCODE = 4 (NOTIFY),
+OPCODE = 5 (UPDATE) and OPCODE = 6 (DNS Stateful Operations, DSO). OPCODE = 1 (IQUERY)
+is obsolete and OPCODE = 2 (STATUS) is not specified. OPCODE = 3 is reserved.
+
+The allowable values of QDCOUNT are specified in {{?RFC1035}} without the clarity
+of normative language, and this looseness of language results in some ambiguity.
+
+# Updates to RFC 1035
+
+A DNS message with OPCODE = 0 (QUERY) MUST NOT include a QDCOUNT parameter whose
+value is greater than 1. It follows that the Question Section of a DNS message with OPCODE = 0
+MUST NOT contain more than one question.
+
+A DNS message with OPCODE = 0 (QUERY) and QDCOUNT > 1 MUST be treated as an incorrectly-formatted
+message. If a response is generated for a query that includes more than one question, the value
+of the RCODE parameter in the response message MUST be set to 1 (FORMERR).
+
+Firewalls that process DNS messages in order to eliminate unwanted traffic MAY treat messages
+with OPCODE = 0 and QDCOUNT > 1 as unwanted traffic.
 
 # Security Considerations
 
-This document has no security implications.
+This document clarifies the DNS specification and aims to improve
+interoperability between different DNS implementations. In general, the elimination of ambiguity
+seems well-aligned with security hygiene.
 
 # IANA Considerations
 

--- a/draft-bellis-dnsop-qdcount-is-one.md
+++ b/draft-bellis-dnsop-qdcount-is-one.md
@@ -47,34 +47,34 @@ behaviour when values that are not allowed are encountered.
 
 # Introduction
 
-The DNS protocol {{!RFC1034}{{!RFC1035}} includes a parameter QDCOUNT in the
-DNS message header, whose value is specified to mean the number
-of questions in the Question Section of a message.
+The DNS protocol {{!RFC1034}{{!RFC1035}} includes a parameter QDCOUNT
+in the DNS message header, whose value is specified to mean the
+number of questions in the Question Section of a message.
 
-In a general
-sense it seems perfectly plausible for the QDCOUNT parameter, an unsigned
-16-bit value, to take a considerable range of values. However, in the
-specific case of messages that encode DNS queries and responses (messages with OPCODE
-= 0) there are other limitations inherent in the protocol that constrain
-values of QDCOUNT to be either 0 or 1. In particular, several parameters
-specified for DNS response messages such as AA and RCODE have no defined
-meaning when the message contains multiple queries, since there is no way
-to signal which question those parameters relate to.
+In a general sense it seems perfectly plausible for the QDCOUNT
+parameter, an unsigned 16-bit value, to take a considerable range
+of values. However, in the specific case of messages that encode
+DNS queries and responses (messages with OPCODE = 0) there are other
+limitations inherent in the protocol that constrain values of QDCOUNT
+to be either 0 or 1. In particular, several parameters specified
+for DNS response messages such as AA and RCODE have no defined
+meaning when the message contains multiple queries, since there is
+no way to signal which question those parameters relate to.
 
-In this document we briefly survey the existing written DNS specification;
-we provide a description of the semantic and practical requirements for
-DNS queries that naturally constrain the allowable values of QDCOUNT; and
-we update the DNS base specification to clarify the allowable values
-of the QDCODE parameter in the specific case of DNS messages with OPCODE = 0
-(QUERY).
+In this document we briefly survey the existing written DNS
+specification; we provide a description of the semantic and practical
+requirements for DNS queries that naturally constrain the allowable
+values of QDCOUNT; and we update the DNS base specification to
+clarify the allowable values of the QDCODE parameter in the specific
+case of DNS messages with OPCODE = 0 (QUERY).
 
 # Terminology used in this document
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
-"SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
-"OPTIONAL" in this document are to be interpreted as described in BCP 14
-{{!RFC2119}} {{!RFC8174}} when, and only when, they appear in all
-capitals, as shown here.
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY",
+and "OPTIONAL" in this document are to be interpreted as described
+in BCP 14 {{!RFC2119}} {{!RFC8174}} when, and only when, they appear
+in all capitals, as shown here.
 
 # QDCOUNT is (usually) One
 
@@ -84,21 +84,24 @@ QDCOUNT in the written DNS specification.
 ## OPCODE = 0 (QUERY) and 1 (IQUERY)
 
 {{!RFC1035}} significantly predates the use of normative requirements
-keywords, and parts of it are consequently somewhat open to interpretation.
+keywords, and parts of it are consequently somewhat open to
+interpretation.
 
-Section 4.1.2 ("Question section format") has this to say about QDCOUNT:
+Section 4.1.2 ("Question section format") has this to say about
+QDCOUNT:
 
 > The section contains QDCOUNT (usually 1) entries
 
-The only documented exceptions within {{!RFC1035}} relate to
-the IQuery Opcode, where the request has "an empty question section"
+The only documented exceptions within {{!RFC1035}} relate to the
+IQuery Opcode, where the request has "an empty question section"
 (QDCOUNT == 0), and "zero, one, or multiple domain names for the
-specified resource as QNAMEs in the question section". The IQuery OpCode
-was made obsolete in {{!RFC3425}}.
+specified resource as QNAMEs in the question section". The IQuery
+OpCode was made obsolete in {{!RFC3425}}.
 
-In the absence of clearly expressed normative requirements, we rely on
-other text in {{!RFC1035}} that makes use of the definite article or
-other text that implies a singuar question, and therefore QDCOUNT == 1.
+In the absence of clearly expressed normative requirements, we rely
+on other text in {{!RFC1035}} that makes use of the definite article
+or other text that implies a singuar question and, by implication,
+QDCOUNT = 1.
 
 For example, Section 4.1:
 
@@ -115,10 +118,10 @@ and in Section 4.1.1. ("Header section format"):
 >    and specifies that the responding name server is an
 >    authority for the domain name in question section.
 
-DNS Cookies {{?RFC7873}} in Section 5.4 allow a client to receive a
-valid Server Cookie without sending a specific question by sending a
-Query packet (OpCode 0) with QDCOUNT == 0, with the resulting response
-also containing no question.
+DNS Cookies {{?RFC7873}} in Section 5.4 allow a client to receive
+a valid Server Cookie without sending a specific question by sending
+a Query packet (OpCode 0) with QDCOUNT == 0, with the resulting
+response also containing no question.
 
 ## OPCODE = 4 (NOTIFY)
 
@@ -132,8 +135,8 @@ tuple in the singular.
 
 ## OPCODE = 5 (UPDATE)
 
-DNS Update {{?RFC2136}} renames the QDCOUNT field to ZOCOUNT, but the
-value is constrained to be one by Section 2.3 ("Zone Section"):
+DNS Update {{?RFC2136}} renames the QDCOUNT field to ZOCOUNT, but
+the value is constrained to be one by Section 2.3 ("Zone Section"):
 
 > All records to be updated must be in the same zone, and therefore the
 > Zone Section is allowed to contain exactly one record.
@@ -141,44 +144,50 @@ value is constrained to be one by Section 2.3 ("Zone Section"):
 ## OPCODE = 6 (DNS Stateful Operations, DSO)
 
 DNS Stateful Operations {{?RFC8490}} (DSO - OpCode 6) attempts to
-preserve compatibility with the standard DNS 12 octet header, and does
-so by requiring that all four of the section count values be set to
-zero.
+preserve compatibility with the standard DNS 12 octet header, and
+does so by requiring that all four of the section count values be
+set to zero.
 
 ## Conclusion
 
-There is no description in {{!RFC1035}} that describes how other parameters
-in the DNS message such as AA, RCODE should be interpreted in the case
-where a message includes more than one question. An originator of a query
-with QDCOUNT > 1 can have no expectations of how it will be processed,
-and the receiver of a response with QDCOUNT > 1 has no guidance for how it
-should be interpreted.
+There is no description in {{!RFC1035}} that describes how other
+parameters in the DNS message such as AA, RCODE should be interpreted
+in the case where a message includes more than one question. An
+originator of a query with QDCOUNT > 1 can have no expectations of
+how it will be processed, and the receiver of a response with QDCOUNT
+> 1 has no guidance for how it should be interpreted.
 
-The allowable values of QDCOUNT seem to be clearly specified for OPCODE = 4 (NOTIFY),
-OPCODE = 5 (UPDATE) and OPCODE = 6 (DNS Stateful Operations, DSO). OPCODE = 1 (IQUERY)
-is obsolete and OPCODE = 2 (STATUS) is not specified. OPCODE = 3 is reserved.
+The allowable values of QDCOUNT seem to be clearly specified for
+OPCODE = 4 (NOTIFY), OPCODE = 5 (UPDATE) and OPCODE = 6 (DNS Stateful
+Operations, DSO). OPCODE = 1 (IQUERY) is obsolete and OPCODE = 2
+(STATUS) is not specified. OPCODE = 3 is reserved.
 
-The allowable values of QDCOUNT are specified in {{?RFC1035}} without the clarity
-of normative language, and this looseness of language results in some ambiguity.
+The allowable values of QDCOUNT are specified in {{?RFC1035}} without
+the clarity of normative language, and this looseness of language
+results in some ambiguity.
 
 # Updates to RFC 1035
 
-A DNS message with OPCODE = 0 (QUERY) MUST NOT include a QDCOUNT parameter whose
-value is greater than 1. It follows that the Question Section of a DNS message with OPCODE = 0
-MUST NOT contain more than one question.
+A DNS message with OPCODE = 0 (QUERY) MUST NOT include a QDCOUNT
+parameter whose value is greater than 1. It follows that the Question
+Section of a DNS message with OPCODE = 0 MUST NOT contain more than
+one question.
 
-A DNS message with OPCODE = 0 (QUERY) and QDCOUNT > 1 MUST be treated as an incorrectly-formatted
-message. If a response is generated for a query that includes more than one question, the value
-of the RCODE parameter in the response message MUST be set to 1 (FORMERR).
+A DNS message with OPCODE = 0 (QUERY) and QDCOUNT > 1 MUST be treated
+as an incorrectly-formatted message. If a response is generated for
+a query that includes more than one question, the value of the RCODE
+parameter in the response message MUST be set to 1 (FORMERR).
 
-Firewalls that process DNS messages in order to eliminate unwanted traffic MAY treat messages
-with OPCODE = 0 and QDCOUNT > 1 as unwanted traffic.
+Firewalls that process DNS messages in order to eliminate unwanted
+traffic MAY treat messages with OPCODE = 0 and QDCOUNT > 1 as
+unwanted traffic.
 
 # Security Considerations
 
 This document clarifies the DNS specification and aims to improve
-interoperability between different DNS implementations. In general, the elimination of ambiguity
-seems well-aligned with security hygiene.
+interoperability between different DNS implementations. In general,
+the elimination of ambiguity seems well-aligned with security
+hygiene.
 
 # IANA Considerations
 


### PR DESCRIPTION
I tried to tighten up some of the language around fields, parameters and values. I don't know how we are supposed to capitalise OPCODE so this document includes both that and OpCode.

I tried to anticipate some questions and, in some places, make the text a little less pugilent.

Most of your nicely-researched QDCOUNT citations were fine; as expected, it's only really
RFC 1035 that needs to be updated, and only for OPCODE = 0. So I made it clear that 1035
is the only document that we are updating.

I added some FORMERR bits and pieces and some normative language about that.

I updated my author details.

I probably made some changes that were unnecessary. Definitely feel free to back those out as you see fit.